### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ See [documentation](https://docs.dagger.io) for more information about dagger mo
 | [nix](./nix)                | Nix package manager |
 | [nixpacks](./nixpacks/)     | Build an OCI image of your project using [nixpacks](https://nixpacks.com/) |
 | [open-policy-agent](./open-policy-agent/)  | Daggerized version of [Open Policy Agent](https://www.openpolicyagent.org/) |
-| [phpcbf](./phpcbf/)         | Daggerized version of [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer) |
-| [phpcs](./phpcs/)           | PHP Code Sniffer [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) |
+| [phpcbf](./phpcbf/)         | Daggerized version of [phpcbf](https://github.com/PHPCSStandards/PHP_CodeSniffer) |
+| [phpcs](./phpcs/)           | PHP Code Sniffer [phpcs](https://github.com/PHPCSStandards/PHP_CodeSniffer) |
 | [php-cs-fixer](./php-cs-fixer/) | PHP Coding Standards Fixer [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) |
 | [pkgx](./pkgx/)             | Daggerized version of [pkgx](https://pkgx.sh) |
 | [r2-sync](./r2-sync/)       | Sync files from local directory to Cloudflare [R2](https://www.cloudflare.com/developer-platform/r2/) |

--- a/phpcbf/README.md
+++ b/phpcbf/README.md
@@ -3,7 +3,7 @@
 [![dagger-min-version](https://shield.fluentci.io/dagger/v0.11.7)](https://dagger.io)
 ![deno compatibility](https://shield.deno.dev/deno/^1.41)
 
-Daggerized version of [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer).
+Daggerized version of [phpcbf](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 
 ## Usage
 

--- a/phpcs/README.md
+++ b/phpcs/README.md
@@ -3,7 +3,7 @@
 [![dagger-min-version](https://shield.fluentci.io/dagger/v0.11.7)](https://dagger.io)
 ![deno compatibility](https://shield.deno.dev/deno/^1.41)
 
-Daggerized version of [phpcs](https://github.com/squizlabs/PHP_CodeSniffer).
+Daggerized version of [phpcs](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 
 ## Usage
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932